### PR TITLE
ci: update upload-sarif action for DevSkim and nodejsscan

### DIFF
--- a/.github/workflows/devskim.yml
+++ b/.github/workflows/devskim.yml
@@ -29,6 +29,6 @@ jobs:
         uses: microsoft/DevSkim-Action@v1
 
       - name: Upload DevSkim scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: devskim-results.sarif

--- a/.github/workflows/njsscan.yml
+++ b/.github/workflows/njsscan.yml
@@ -37,6 +37,6 @@ jobs:
       with:
         args: '. --sarif --output results.sarif || true'
     - name: Upload njsscan report
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: results.sarif


### PR DESCRIPTION
The v2 of the action is now deprectated and has stopped working, so the update to v3 is required.
See https://github.blog/changelog/2025-01-10-code-scanning-codeql-action-v2-is-now-deprecated/.

## Summary by Sourcery

CI:
- Bump github/codeql-action/upload-sarif from v2 to v3 in DevSkim and njsscan workflows to restore SARIF upload to the Security tab.