### PR TITLE
ci: update Codecov action to version 4.4.0

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -30,7 +30,7 @@ jobs:
         timeout_minutes: 15
     - run: yarn test --coverage
     - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v4.0.1
+      uses: codecov/codecov-action@v4.4.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         slug: romw314/chess-no-25


### PR DESCRIPTION
Fixes the EPIPE error when uploading coverage reports (codecov/codecov-action#1280).

## Summary by Sourcery

CI:
- Bump Codecov GitHub Action from v4.0.1 to v4.4.0 in the Node.js workflow to address coverage upload issues.